### PR TITLE
Add shebang

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # check_domain - v2.0.0
 # Author: A. Stoyanov
 # GitHub: https://github.com/a-stoyanov/zabbix-domain-expiry
@@ -47,7 +48,6 @@
 #   - Debug output is enabled with -z and sent to stderr.
 #   - Temporary files are cleaned up on exit.
 
-#!/bin/sh
 set -e
 exec 2>&1
 


### PR DESCRIPTION
It is a good practice to write a so-called shebang at the beginning of scripts. Let's change this script a little. 
This will allow you to install the script by downloading it directly from github. 
And, perhaps, it will solve other unknown problems.